### PR TITLE
Update file_.py

### DIFF
--- a/flika/process/file_.py
+++ b/flika/process/file_.py
@@ -47,7 +47,7 @@ def save_file(filename=None):
         filename = os.path.join(directory, filename)
     g.m.statusBar().showMessage(f'Saving {os.path.basename(filename)}')
     A = g.win.image
-    if A.dtype == np.bool:
+    if A.dtype == bool:
         A = A.astype(np.uint8)
     metadata = g.win.metadata
     try:
@@ -329,7 +329,7 @@ def open_file(filename=None, from_gui=False):
             g.settings['recent_files'].remove(filename)
         # make_recent_menu()
         return
-        
+
     append_recent_file(str(filename))  # make first in recent file menu
     msg = f'{os.path.basename(str(filename))} successfully loaded ({time.time() - t} s)'
     g.m.statusBar().showMessage(msg)
@@ -454,7 +454,7 @@ def open_points(filename=None):
 
 
 
-    
+
 ########################################################################################################################
 ######################                INTERNAL HELPER FUNCTIONS                              ###########################
 ########################################################################################################################

--- a/flika/process/filters.py
+++ b/flika/process/filters.py
@@ -742,7 +742,7 @@ class Boxcar_differential_filter(BaseProcess):
                 cnt=np.array([np.array([np.array([p[1],p[0]])]) for p in self.roi.pts ])
                 mask=np.zeros(self.tif[0,:,:].shape,np.uint8)
                 cv2.drawContours(mask,[cnt],0,255,-1)
-                mask=mask.reshape(mx*my).astype(np.bool)
+                mask=mask.reshape(mx*my).astype(bool)
                 tif=self.tif.reshape((mt,mx*my))
                 tif=tif[:,mask]
                 newtrace=np.zeros(mt)

--- a/flika/process/roi.py
+++ b/flika/process/roi.py
@@ -67,7 +67,7 @@ class Set_value(BaseProcess):
             inside_bounds=(xx>=0) & (yy>=0) & (xx<mx) & (yy<my)
             xx=xx[inside_bounds]
             yy=yy[inside_bounds]
-            mask=np.ones((mx,my),np.bool)
+            mask=np.ones((mx,my),bool)
             mask[xx,yy]=False
             if nDim==2:
                 self.newtif[mask]=value

--- a/flika/process/stacks.py
+++ b/flika/process/stacks.py
@@ -282,7 +282,7 @@ class Trim(BaseProcess):
             self.newtif=self.tif[firstFrame:lastFrame+1:increment]
         if delete:
             idxs_not=np.arange(firstFrame, lastFrame+1, increment)
-            idxs = np.ones(len(self.tif),dtype=np.bool)
+            idxs = np.ones(len(self.tif),dtype=bool)
             idxs[idxs_not] = False
             self.newtif = self.tif[idxs]
         self.newname=self.oldname+' - Kept Stack'


### PR DESCRIPTION
Replaced np.bool with builtin bool as np.bool deprecated since NumPy v1.2. This should fix file save error when FLIKA run on py v3.11